### PR TITLE
Fix conditional for existence of the TextChangedP

### DIFF
--- a/plugin/keysound.vim
+++ b/plugin/keysound.vim
@@ -33,13 +33,13 @@ function! s:keysound_init(enable)
 				au! 
 				au InsertEnter * call s:event_insert_enter()
 				au TextChangedI * call s:event_text_changed()
+				au TextChangedP * call s:event_text_changed()
 			augroup END
 		else
 			augroup KeysoundEvents
 				au! 
 				au InsertEnter * call s:event_insert_enter()
 				au TextChangedI * call s:event_text_changed()
-				au TextChangedP * call s:event_text_changed()
 			augroup END
 		endif
 	endif


### PR DESCRIPTION
The conditional had to be flipped around since the TextChangedP
was not available in all Vim versions and led to an error.