### PR TITLE
Add documentation for `pysdl2-dll` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Install sdl2 with brew:
 brew install sdl2
 ```
 
+In alternative, it is possible to install the `pysdl2-dll`, a package that bundles the binary for `sdl2` for Windows and macOS.
+
+```bash
+pip3 install pysdl2-dll
+```
+
 # About
 
 TODO


### PR DESCRIPTION
The previous instruction didn't work correctly for macOS 13 Ventura. Instead, `pysedl2-dll` worked perfectly without any further documentation. I think it is worth mentioning it in the README.